### PR TITLE
Fix version number displayed with -V

### DIFF
--- a/coinx.js
+++ b/coinx.js
@@ -4,7 +4,7 @@
 var program = require('commander');
 
 program
-  .version('0.2.1')
+  .version(require('./package.json').version)
   .command('price [symbol]', 'get the price of a coin from all exchanges').alias('p')
   .command('buy [symbol]', 'buy a coin from an exchange. Auto finds the best price.').alias('b')
   .command('config [exchange]', 'set your api keys for an exchange').alias('c')


### PR DESCRIPTION
After updating, I noticed the version number was still displaying `0.2.1`. Now the version number will always display the version found in `package.json`